### PR TITLE
feature / add Flag component

### DIFF
--- a/__tests__/Flag.spec.tsx
+++ b/__tests__/Flag.spec.tsx
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render } from '@testing-library/react'
+import React from 'react'
+import Flag from '../src/components/Flag'
+
+describe('Flag props', () => {
+  test('should render with given className', () => {
+    const customClass: string = 'customClass'
+    const { container } = render(<Flag className={customClass} />)
+    expect(container!.firstChild).toHaveClass('info', customClass)
+  })
+
+  test('should render with remainFlags', () => {
+    const remainFlags: number = 3
+    const { container } = render(<Flag remainFlags={remainFlags} />)
+    const text = container.querySelector('.info__text')
+    expect(text?.textContent).toBe(String(remainFlags))
+  })
+})

--- a/__tests__/Grid.spec.tsx
+++ b/__tests__/Grid.spec.tsx
@@ -13,7 +13,7 @@ describe('Grid component props', () => {
     expect(container!.firstChild?.textContent).toBe('')
   })
 
-  test('should render with passing className', () => {
+  test('should render with given className', () => {
     const customClass: string = 'customClass'
     const { container } = render(<Grid className={customClass} />)
     expect(container!.firstChild).toHaveClass('grid', customClass)
@@ -49,28 +49,28 @@ describe('Grid component props', () => {
   })
 
   test('should trigger event "onClick"', () => {
-    const handleClick = jest.fn()
+    const handleClick: jest.Mock = jest.fn()
     const { container } = render(<Grid onClick={handleClick} />)
     fireEvent.click(container!.firstChild)
     expect(handleClick).toHaveBeenCalledTimes(1)
   })
 
   test('should trigger event "onClick" only when inactive', () => {
-    const handleClick = jest.fn()
+    const handleClick: jest.Mock = jest.fn()
     const { container } = render(<Grid onClick={handleClick} isActive />)
     fireEvent.click(container!.firstChild)
     expect(handleClick).toHaveBeenCalledTimes(0)
   })
 
   test('should trigger event "onMarked" if defined', () => {
-    const handleMarked = jest.fn()
+    const handleMarked: jest.Mock = jest.fn()
     const { container } = render(<Grid onMarked={handleMarked} />)
     fireEvent.contextMenu(container!.firstChild)
     expect(handleMarked).toHaveBeenCalledTimes(1)
   })
 
   test('should trigger event "onMarked" only when inactive', () => {
-    const handleMarked = jest.fn()
+    const handleMarked: jest.Mock = jest.fn()
     const { container } = render(<Grid onMarked={handleMarked} isActive />)
     fireEvent.contextMenu(container!.firstChild)
     expect(handleMarked).toHaveBeenCalledTimes(0)

--- a/__tests__/Timer.spec.tsx
+++ b/__tests__/Timer.spec.tsx
@@ -7,22 +7,28 @@ import React from 'react'
 import Timer from '../src/components/Timer'
 
 describe('Timer components props', () => {
+  test('should render with given className', () => {
+    const customClass: string = 'customClass'
+    const { container } = render(<Timer className={customClass} />)
+    expect(container!.firstChild).toHaveClass('info', customClass)
+  })
+
   test('should render with given seconds, and prepended 0', () => {
     const { container } = render(<Timer seconds={1} />)
-    const displayText = container!.querySelector('.timer__seconds')
+    const displayText: Element | null = container!.querySelector('.info__text')
     expect(displayText?.textContent).toBe('001')
   })
 
   test('should render "999+" when the seconds is over 999', () => {
     const { container } = render(<Timer seconds={1000} />)
-    const displayText = container!.querySelector('.timer__seconds')
+    const displayText: Element | null = container!.querySelector('.info__text')
     expect(displayText?.textContent).toBe('999+')
   })
 
   test('should displaying time change every second', () => {
     jest.useFakeTimers()
     const { container } = render(<Timer running />)
-    const displayTime = container!.querySelector('.timer__seconds')
+    const displayTime: Element | null = container!.querySelector('.info__text')
     expect(displayTime?.textContent).toBe('000')
 
     /*
@@ -38,7 +44,7 @@ describe('Timer components props', () => {
 
   test('should onChange triggered if defined', () => {
     jest.useFakeTimers()
-    const handleChange = jest.fn()
+    const handleChange: jest.Mock = jest.fn()
     render(<Timer running onChange={handleChange} />)
 
     act(() => {

--- a/scss/components/controls.scss
+++ b/scss/components/controls.scss
@@ -1,8 +1,15 @@
+@import "../function";
+
 .controls {
   display: flex;
   align-items: center;
+  justify-content: center;
 
-  &__mines {
-    margin-left: auto;
+  > *:not(:first-child) {
+    margin-left: spacing-ratio(4);
+  }
+
+  &__flags {
+    width: 75px !important;
   }
 }

--- a/scss/components/info.scss
+++ b/scss/components/info.scss
@@ -1,6 +1,6 @@
 @import "../function";
 
-.timer {
+.info {
   display: flex;
   align-items: center;
 
@@ -18,7 +18,7 @@
     height: $size;
   }
 
-  &__seconds {
+  &__text {
     margin-left: auto;
     transform: translateY(1px);
   }

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,9 +1,37 @@
 import React from 'react'
+import PropTypes from 'prop-types'
+import clsx from 'clsx'
 import ControlsStyle from 'scss/components/controls.scss'
+import Timer from '~/components/Timer'
+import Flag from '~/components/Flag'
+// import { Level } from '~/constants/level'
 
-export default () => (
-  <div className={ControlsStyle.controls}>
-    <div>Time</div>
-    <div className={ControlsStyle.controls__mines}>Input Mine</div>
+const ControlsProps = {
+  className: PropTypes.string,
+  // level: PropTypes.oneOf(Object.values(Level)),
+  seconds: PropTypes.number,
+  remainFlags: PropTypes.number,
+  running: PropTypes.bool,
+  onTimeChange: PropTypes.func,
+}
+
+const Controls = ({
+  className, seconds, remainFlags, running, onTimeChange,
+}: PropTypes.InferProps<typeof ControlsProps>) => (
+  <div className={clsx(ControlsStyle.controls, className)}>
+    <Timer seconds={seconds} running={running} onChange={onTimeChange} />
+    <Flag className={ControlsStyle.controls__flags} remainFlags={remainFlags} />
   </div>
 )
+
+Controls.propTypes = ControlsProps
+Controls.defaultProps = {
+  className: undefined,
+  // level: Level.Easy,
+  seconds: 0,
+  remainFlags: 0,
+  running: false,
+  onTimeChange: undefined,
+}
+
+export default Controls

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import clsx from 'clsx'
+import InfoStyle from 'scss/components/info.scss'
+import FlagIcon from 'assets/img/ic-flag.png'
+
+const FlagProps = {
+  className: PropTypes.string,
+  remainFlags: PropTypes.number,
+}
+
+const Flag = ({ className, remainFlags }: PropTypes.InferProps<typeof FlagProps>) => (
+  <div className={clsx(InfoStyle.info, className)}>
+    <img className={InfoStyle.info__icon} src={FlagIcon} alt="" />
+    <span className={InfoStyle.info__text}>
+      { remainFlags || '0' }
+    </span>
+  </div>
+)
+
+Flag.propTypes = FlagProps
+Flag.defaultProps = {
+  className: undefined,
+  remainFlags: 0,
+}
+
+export default Flag

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -1,15 +1,19 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import TimerStyle from 'scss/components/timer.scss'
+import clsx from 'clsx'
+import InfoStyle from 'scss/components/info.scss'
 import timerIcon from 'assets/img/ic-stopwatch.png'
 
 const TimerProps = {
+  className: PropTypes.string,
   seconds: PropTypes.number,
   running: PropTypes.bool,
   onChange: PropTypes.func,
 }
 
-const Timer = ({ seconds, running, onChange }: PropTypes.InferProps<typeof TimerProps>) => {
+const Timer = ({
+  className, seconds, running, onChange,
+}: PropTypes.InferProps<typeof TimerProps>) => {
   const [time, setTime] = useState(seconds || 0)
   const [prevSeconds, setPrevSeconds] = useState(0)
   const displaySeconds = (time || 0).toString().padStart(3, '0')
@@ -37,13 +41,13 @@ const Timer = ({ seconds, running, onChange }: PropTypes.InferProps<typeof Timer
   }
 
   return (
-    <div className={TimerStyle.timer}>
+    <div className={clsx(InfoStyle.info, className)}>
       <img
-        className={TimerStyle.timer__icon}
+        className={InfoStyle.info__icon}
         src={timerIcon}
         alt=""
       />
-      <span className={TimerStyle.timer__seconds}>
+      <span className={InfoStyle.info__text}>
         { time > 999 ? '999+' : displaySeconds }
       </span>
     </div>
@@ -52,6 +56,7 @@ const Timer = ({ seconds, running, onChange }: PropTypes.InferProps<typeof Timer
 
 Timer.propTypes = TimerProps
 Timer.defaultProps = {
+  className: undefined,
   seconds: 0,
   running: false,
   onChange: undefined,


### PR DESCRIPTION
### Description
- Add a new component *Flag* for displaying the remaining flags, and add unit test for the component
- Support `className` prop in *Timer* and add its unit test
- Rename *timer.scss* to *info.scss* because the style can be reused
- Modify syntax of unit test

### Screenshots
- UI
<img width="332" alt="Screenshot 2021-10-12 at 11 02 14 PM" src="https://user-images.githubusercontent.com/7455359/136981112-3d29e9b2-e6f9-4b70-8ea4-7be48917e7e9.png">

- Unit test
<img width="672" alt="Screenshot 2021-10-12 at 11 02 41 PM" src="https://user-images.githubusercontent.com/7455359/136981156-9736db1a-0bc1-4884-99eb-2118234db838.png">
