### PR TITLE
feature / add the explore logic for MineMap

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
   ],
   "rules": {
     "no-use-before-define": "off",
+    "no-plusplus": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-use-before-define": ["error"],

--- a/__tests__/mines.spec.ts
+++ b/__tests__/mines.spec.ts
@@ -1,0 +1,60 @@
+import { GridData } from '~/components/MineMap'
+import {
+  createMapFactory,
+  placeSingleMine,
+  placeMines,
+  exploreGrid,
+} from '~/utils/mines'
+
+describe('Utils: MineMap utils', () => {
+  const row: number = 8
+  const column: number = 6
+  let map: GridData[][] = []
+
+  beforeEach(() => {
+    map = createMapFactory(row, column)
+  })
+
+  test('should create a map with designated rows and columns', () => {
+    expect(map.length).toBe(row)
+    expect(map[0].length).toBe(column)
+  })
+
+  test('should randomly set a mine to a grid', () => {
+    let count: number = 0
+
+    placeSingleMine(map)
+    for (let r = 0; r < row; r++) {
+      for (let c = 0; c < column; c++) {
+        if (map[r][c].isMine) {
+          count++
+        }
+      }
+    }
+
+    expect(count).toBe(1)
+  })
+
+  test('should place designated number of mines to the map', () => {
+    const totalMines = 10
+    let count: number = 0
+
+    placeMines(map, totalMines)
+    for (let r = 0; r < row; r++) {
+      for (let c = 0; c < column; c++) {
+        if (map[r][c].isMine) {
+          count++
+        }
+      }
+    }
+
+    expect(count).toBe(totalMines)
+  })
+
+  test('should change the state of a grid to clicked: true & marked: false when clicked', () => {
+    const grid: GridData = map[1][1]
+    exploreGrid(grid, map)
+    expect(grid.clicked).toBe(true)
+    expect(grid.marked).toBe(false)
+  })
+})

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,3 +3,11 @@ declare module '*.scss'
 declare module '*.JPG'
 declare module '*.png'
 declare module '*.svg'
+
+declare type GridData = {
+  index: string,
+  adjacentMines?: number,
+  isMine: boolean,
+  clicked: boolean,
+  marked: boolean
+}

--- a/src/utils/mines.ts
+++ b/src/utils/mines.ts
@@ -1,0 +1,93 @@
+// eslint-disable-next-line arrow-body-style
+export const createMapFactory = (rows: number, columns: number): GridData[][] => {
+  // eslint-disable-next-line arrow-body-style
+  return Array.from({ length: rows }, (_el, row: number) => {
+    return Array.from({ length: columns }, (_e, column: number) => ({
+      index: `${row}_${column}`,
+      adjacentMines: undefined,
+      isMine: false,
+      clicked: false,
+      marked: false,
+    }))
+  })
+}
+
+export const placeSingleMine = (map: GridData[][]): void => {
+  const row: number = Math.floor(Math.random() * map.length)
+  const col: number = Math.floor(Math.random() * map[0].length)
+
+  if (!map[row] || !map[row][col]) {
+    return
+  }
+
+  if (!map[row][col].isMine) {
+    // eslint-disable-next-line no-param-reassign
+    map[row][col].isMine = true
+  } else {
+    placeSingleMine(map)
+  }
+}
+
+export const placeMines = (map: GridData[][], totalMines: number): void => {
+  const total = Math.min(map.length * map[0].length, totalMines)
+  for (let count = 0; count < total; count++) {
+    placeSingleMine(map)
+  }
+}
+
+export const getAdjacentMines = (row: number, column: number, map: GridData[][]): number => {
+  let count: number = 0
+  for (let rowOffset = -1; rowOffset < 2; rowOffset++) {
+    for (let columnOffset = -1; columnOffset < 2; columnOffset++) {
+      const grid: GridData | undefined = map[row + rowOffset]
+        ? map[row + rowOffset][column + columnOffset]
+        : undefined
+
+      if (grid?.isMine) {
+        count++
+      }
+    }
+  }
+  return count
+}
+
+export const exploreGrid = (grid: GridData, map: GridData[][]): void => {
+  if (grid.clicked || grid.marked) {
+    return
+  }
+
+  // eslint-disable-next-line no-param-reassign
+  grid.clicked = true
+  // eslint-disable-next-line no-param-reassign
+  grid.marked = false
+  if (grid.isMine) {
+    // TODO
+  } else {
+    const [row, column] = grid.index.split('_')
+    // eslint-disable-next-line no-param-reassign
+    grid.adjacentMines = getAdjacentMines(Number(row), Number(column), map)
+    if (!grid.adjacentMines) {
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      exploreAdjacentGrid(Number(row), Number(column), map)
+    }
+  }
+}
+
+export const exploreAdjacentGrid = (row: number, column: number, map: GridData[][]): void => {
+  for (let rowOffset = -1; rowOffset < 2; rowOffset++) {
+    for (let columnOffset = -1; columnOffset < 2; columnOffset++) {
+      if (rowOffset === 0 && columnOffset === 0) {
+        // eslint-disable-next-line no-continue
+        continue
+      }
+
+      const grid: GridData | undefined = map[row + rowOffset]
+        ? map[row + rowOffset][column + columnOffset]
+        : undefined
+
+      if (grid && !grid.clicked && !grid.marked) {
+        exploreGrid(grid, map)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
- Implement the logic to explore grid in the map
- Add the unit test for MineMap utils
- Move the type `GridData` to global.d.ts to prevent dependency loop

### Screenshots
<img width="567" alt="Screenshot 2021-10-14 at 11 23 34 PM" src="https://user-images.githubusercontent.com/7455359/137348295-f1cd5e79-b0c9-4997-9f17-2a2aad628698.png">

